### PR TITLE
Made Sec-WebSocket-Key header matching case insensitive

### DIFF
--- a/src/main/scala/spray/can/server/websockets/Sockets.scala
+++ b/src/main/scala/spray/can/server/websockets/Sockets.scala
@@ -84,7 +84,8 @@ object Sockets extends ExtensionKey[SocketExt]{
 
   def calculateReturnHash(headers: List[HttpHeader]) = {
     headers.collectFirst{
-      case RawHeader("Sec-WebSocket-Key", value) => (value + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").getBytes("UTF-8")
+      case header if(header is "sec-websocket-key") =>
+        (header.value + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").getBytes("UTF-8")
     }.map(MessageDigest.getInstance("SHA-1").digest)
       .map(new sun.misc.BASE64Encoder().encode)
   }


### PR DESCRIPTION
When running a websocket server on Heroku the handshake request contains a `Sec-Websocket-Key` header instead of `Sec-WebSocket-Key`. 

That should fix it.
